### PR TITLE
Added functionality for 0 in text

### DIFF
--- a/code.php
+++ b/code.php
@@ -169,7 +169,7 @@ if ( empty( $_GET['text'] ) || ! isset( $_GET['text'] ) ) {
 	}
 }
 
-if ( isset( $_GET['text'] ) && $_GET['text'] ) {
+if ( isset( $_GET['text'] ) && ($_GET['text'] || $_GET['text']==0 || $_GET['text']=="0") ) {
 	$_GET['text'] = preg_replace_callback(
 		"/(0x[0-9A-F]{,3})/ui",
 		function( $matches ) {


### PR DESCRIPTION
I tried to solve the issue #13 

This solution will most probably work if a person adds "0" in the text section.

The reason it didn't work was line 172, $_GET['text'] which will of course see 0 and return false, making the compiler jump the if statements.
I hope this gets the job done.