### PR TITLE
Remove and update some URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,21 +351,21 @@ if ( top != self ) { top.location.href = 'https://dummyimage.com/'; }
 <p id="license">Dummy Image is written in PHP and distributed freely under a <a rel="license" href="http://creativecommons.org/licenses/MIT/">MIT License</a>.</p>
 <h4 id="other-downloads">Other Versions</h4>
 <dl>
-  <dt><a href="http://github.com/xxx/fakeimage" target="_blank">Fakeimage</a></dt>
+  <dt><a href="https://github.com/xxx/fakeimage" target="_blank">Fakeimage</a></dt>
   <dd class="language">Ruby</dd>
   <dd class="author">Michael Dungan</dd>
-  <dt><a href="http://code.google.com/p/aspnet-dummyimage/" target="_blank">ASP.net Dummy Image</a></dt>
+  <dt><a href="https://code.google.com/p/aspnet-dummyimage/" target="_blank">ASP.net Dummy Image</a></dt>
   <dd class="language">ASP.net</dd>
   <dd class="author">Jess Tedder</dd>
   <dt><a href="https://github.com/darkrho/django-dummyimage" target="_blank">Dynamic Dummy Image Generator for Django</a></dt>
   <dd class="language">Django/Python</dd>
   <dd class="author">Rolando Espinoza La fuente</dd>
-  <dt><a href="http://rndimg.com" target="_blank">Random Image Generator</a></dt>
+  <dt><a href="https://rndimg.com" target="_blank">Random Image Generator</a></dt>
   <dd class="author">Johan Thomsen</dd>
   <dt><a href="https://expressionengine.com/forums/topic/145773" target="_blank">Dummy Image Generator Expression Engine Plugin</a></dt>
   <dd class="language">PHP/Expression Engine</dd>
   <dd class="author">tsiger</dd>
-  <dt><a href="http://www.robertgomez.org/blog/2010/03/03/dummy-image-bookmarklet" target="_blank">Dummy Image Bookmarklet</a></dt>
+  <dt><a href="https://www.robertgomez.org/blog/2010/03/03/dummy-image-bookmarklet" target="_blank">Dummy Image Bookmarklet</a></dt>
   <dd class="language">JavaScript</dd>
   <dd class="author">Robert Gomez</dd>
   <!-- Broken? Unmaintained?
@@ -373,10 +373,10 @@ if ( top != self ) { top.location.href = 'https://dummyimage.com/'; }
   <dd class="language">Python/Google App Engine</dd>
   <dd class="author">Dan Moore</dd>
   -->
-  <dt><a href="http://github.com/derekahmedzai/dummyimages/" target="_blank">Dummyimages Drupal Module</a></dt>
+  <dt><a href="https://github.com/derekahmedzai/dummyimages/" target="_blank">Dummyimages Drupal Module</a></dt>
   <dd class="language">PHP/Drupal</dd>
   <dd class="author">Derek Ahmedzai</dd>
-  <dt><a href="http://drupal.org/project/dummyimage" target="_blank">Dummy image</a></dt>
+  <dt><a href="https://drupal.org/project/dummyimage" target="_blank">Dummy image</a></dt>
   <dd class="language">PHP/Drupal</dd>
   <dd class="author">naxoc</dd>
   <dt><a href="https://soderlind.no/lorem-shortcode/" target="_blank">[lorem] shortcode</a></dt>
@@ -384,11 +384,11 @@ if ( top != self ) { top.location.href = 'https://dummyimage.com/'; }
   <dd class="author">Per Soderlind</dd>
 </dl>
 <h3 id="about">About Russell Heimlich</h3>
-<p>I am <a href="http://www.russellheimlich.com/blog">Russell Heimlich</a> (<a href="http://twitter.com/kingkool68">@kingkool68</a>) and I like to <a href="http://spiritedmedia.com">design web pages</a>, <a href="http://www.russellheimlich.com/blog">blog</a>, and doodle around in <a href="http://www.russellheimlich.com/blog/tags/coding/">JavaScript and PHP</a>.</p>
+<p>I am <a href="https://www.russellheimlich.com/blog">Russell Heimlich</a> (<a href="https://twitter.com/kingkool68">@kingkool68</a>) and I like to <a href="https://spiritedmedia.com">design web pages</a>, <a href="https://www.russellheimlich.com/blog">blog</a>, and doodle around in <a href="https://www.russellheimlich.com/blog/tags/coding/">JavaScript and PHP</a>.</p>
 <h4 id="contact">Contact</h4>
-<p>Still have questions or suggestions? <a href="http://www.russellheimlich.com/contact.html">Contact me</a>.</p>
+<p>Still have questions or suggestions? <a href="https://www.russellheimlich.com/contact.html">Contact me</a>.</p>
 <div id="supported-by">
-<script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIK5Q7&placement=dummyimagecom" id="_carbonads_js"></script>
+<script async type="text/javascript" src="https//cdn.carbonads.com/carbon.js?serve=CKYIK5Q7&placement=dummyimagecom" id="_carbonads_js"></script>
 </div>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
 <script src="js/colorpicker.js" type="text/javascript"></script>

--- a/index.html
+++ b/index.html
@@ -362,36 +362,26 @@ if ( top != self ) { top.location.href = 'https://dummyimage.com/'; }
   <dd class="author">Rolando Espinoza La fuente</dd>
   <dt><a href="http://rndimg.com" target="_blank">Random Image Generator</a></dt>
   <dd class="author">Johan Thomsen</dd>
-  <dt><a href="http://expressionengine.com/forums/viewthread/145773/" target="_blank">Dummy Image Generator Expression Engine Plugin</a></dt>
+  <dt><a href="https://expressionengine.com/forums/topic/145773" target="_blank">Dummy Image Generator Expression Engine Plugin</a></dt>
   <dd class="language">PHP/Expression Engine</dd>
   <dd class="author">tsiger</dd>
   <dt><a href="http://www.robertgomez.org/blog/2010/03/03/dummy-image-bookmarklet" target="_blank">Dummy Image Bookmarklet</a></dt>
   <dd class="language">JavaScript</dd>
   <dd class="author">Robert Gomez</dd>
+  <!-- Broken? Unmaintained?
   <dt><a href="http://ipsumimage.appspot.com/" target="_blank">Ipsum Image</a></dt>
   <dd class="language">Python/Google App Engine</dd>
   <dd class="author">Dan Moore</dd>
-  <dt><a href="http://tumble.dasmith.co.uk/post/519622101/textmate-snippet-for-inserting-dummy-images" target="_blank">Textmate Snippet</a></dt>
-  <dd class="language">Textmate</dd>
-  <dd class="author">Danny Smith</dd>
-  <dt><a href="http://github.com/kennethreitz/DummyImage.tmBundle" target="_blank">Forked Textmate Bundle</a> (<a href="http://github.com/AzizLight/DummyImage.tmBundle" target="_blank">Forked version</a> by Aziz Light)</dt>
-  <dd class="language">Textmate</dd>
-  <dd class="author">Kenneth Reitz</dd>
+  -->
   <dt><a href="http://github.com/derekahmedzai/dummyimages/" target="_blank">Dummyimages Drupal Module</a></dt>
   <dd class="language">PHP/Drupal</dd>
   <dd class="author">Derek Ahmedzai</dd>
-  <dt><a href="http://modxcms.com/extras/package/754" target="_blank">DIG (Dynamic Image Generator)</a></dt>
-  <dd class="language">PHP/MODx CMS</dd>
-  <dd class="author">Brian Wente</dd>
   <dt><a href="http://drupal.org/project/dummyimage" target="_blank">Dummy image</a></dt>
   <dd class="language">PHP/Drupal</dd>
   <dd class="author">naxoc</dd>
-  <dt><a href="http://soderlind.no/archives/2010/11/17/lorem-shortcode/" target="_blank">[lorem] shortcode</a></dt>
+  <dt><a href="https://soderlind.no/lorem-shortcode/" target="_blank">[lorem] shortcode</a></dt>
   <dd class="language">PHP/WordPress</dd>
   <dd class="author">Per Soderlind</dd>
-  <dt><a href="http://typo3.org/extensions/repository/view/fr_dummy_image/current/" target="_blank">Dummy Image ( fr_dummy_image )</a></dt>
-  <dd class="language">PHP/TYPO3</dd>
-  <dd class="author">Robert Ferencek</dd>
 </dl>
 <h3 id="about">About Russell Heimlich</h3>
 <p>I am <a href="http://www.russellheimlich.com/blog">Russell Heimlich</a> (<a href="http://twitter.com/kingkool68">@kingkool68</a>) and I like to <a href="http://spiritedmedia.com">design web pages</a>, <a href="http://www.russellheimlich.com/blog">blog</a>, and doodle around in <a href="http://www.russellheimlich.com/blog/tags/coding/">JavaScript and PHP</a>.</p>


### PR DESCRIPTION
This PR updates some of the "Other Versions" mentioned on the site, since quite a few are either gone or switched places.

Namely, the following changes have been made:

- Changed
  - `http://expressionengine.com/forums/viewthread/145773` to `https://expressionengine.com/forums/topic/145773`
    The old URL was no longer working.
  - `http://soderlind.no/archives/2010/11/17/lorem-shortcode/` to `https://soderlind.no/lorem-shortcode/`
    Site was updated and pages got moved.
  - Commented out `http://ipsumimage.appspot.com/`
    While the site is still responding does it look as if the generator/service itself stopped working? So I didn't remove it completely in case it may work again.
- Removed
  - `http://tumble.dasmith.co.uk/post/519622101/textmate-snippet-for-inserting-dummy-images`
    Site does not respond.
  - `http://github.com/kennethreitz/DummyImage.tmBundle`
    Repository was deleted.
  - `http://modxcms.com/extras/package/754`
    Returns 404
  - `http://typo3.org/extensions/repository/view/fr_dummy_image/current/`
    Returns 404

I also went ahead and updated all `http://` to `https://` because... it's almost 2022 now and no site on earth should use `http://`... ever.